### PR TITLE
feat: add --python option and allow fill/test without nblite.toml

### DIFF
--- a/nblite/cli/commands/fill.py
+++ b/nblite/cli/commands/fill.py
@@ -30,6 +30,7 @@ def _run_fill(
     silent: bool,
     allow_export: bool = False,
     config_path: Path | None = None,
+    python: str | None = None,
 ) -> int:
     """
     Internal fill implementation shared by fill and test commands.
@@ -60,6 +61,24 @@ def _run_fill(
         else:
             os.environ[DISABLE_NBLITE_EXPORT_ENV_VAR] = prev_disable_export
         return 1
+
+    # Resolve effective python: CLI arg > config value
+    effective_python = python or project.config.fill.python
+
+    # Validate python binary early if specified
+    if effective_python:
+        from nblite.fill.kernel import validate_python_binary
+
+        try:
+            validate_python_binary(effective_python)
+        except (FileNotFoundError, PermissionError, RuntimeError) as e:
+            console.print(f"[red]Error: {e}[/red]")
+            # Restore environment variable before returning
+            if prev_disable_export is None:
+                os.environ.pop(DISABLE_NBLITE_EXPORT_ENV_VAR, None)
+            else:
+                os.environ[DISABLE_NBLITE_EXPORT_ENV_VAR] = prev_disable_export
+            return 1
 
     # Collect notebooks to fill
     nbs_to_fill: list[Path] = []
@@ -160,6 +179,17 @@ def _run_fill(
 
         return table
 
+    # Set up kernel environment if custom python is specified
+    from contextlib import ExitStack
+
+    kernel_name = "python3"
+    exit_stack = ExitStack()
+
+    if effective_python:
+        from nblite.fill.kernel import custom_kernel_environment
+
+        kernel_name = exit_stack.enter_context(custom_kernel_environment(effective_python))
+
     # Process notebooks
     def process_one(nb_path: Path) -> FillResult:
         task_statuses[nb_path] = ("run", "Executing...")
@@ -170,6 +200,7 @@ def _run_fill(
             remove_outputs_first=remove_outputs_first,
             clean=clean,
             save_hash=save_hash,
+            kernel_name=kernel_name,
         )
         if result.status == FillStatus.SUCCESS:
             task_statuses[nb_path] = ("ok", "Success")
@@ -179,29 +210,30 @@ def _run_fill(
             task_statuses[nb_path] = ("err", result.message[:50])
         return result
 
-    if silent:
-        # Silent mode - no output during execution
-        if n_workers <= 1:
-            for nb_path in to_process:
-                results.append(process_one(nb_path))
-        else:
-            with ThreadPoolExecutor(max_workers=n_workers) as executor:
-                futures = {executor.submit(process_one, p): p for p in to_process}
-                for future in as_completed(futures):
-                    results.append(future.result())
-    else:
-        # Progress display mode
-        with Live(make_table(), refresh_per_second=4, console=console) as live:
+    with exit_stack:
+        if silent:
+            # Silent mode - no output during execution
             if n_workers <= 1:
                 for nb_path in to_process:
                     results.append(process_one(nb_path))
-                    live.update(make_table())
             else:
                 with ThreadPoolExecutor(max_workers=n_workers) as executor:
                     futures = {executor.submit(process_one, p): p for p in to_process}
                     for future in as_completed(futures):
                         results.append(future.result())
+        else:
+            # Progress display mode
+            with Live(make_table(), refresh_per_second=4, console=console) as live:
+                if n_workers <= 1:
+                    for nb_path in to_process:
+                        results.append(process_one(nb_path))
                         live.update(make_table())
+                else:
+                    with ThreadPoolExecutor(max_workers=n_workers) as executor:
+                        futures = {executor.submit(process_one, p): p for p in to_process}
+                        for future in as_completed(futures):
+                            results.append(future.result())
+                            live.update(make_table())
 
     # Summary
     success_count = sum(1 for r in results if r.status == FillStatus.SUCCESS)
@@ -302,6 +334,10 @@ def fill(
         bool,
         typer.Option("--allow-export", help="Allow nbl_export() during fill (disabled by default)"),
     ] = False,
+    python: Annotated[
+        str | None,
+        typer.Option("--python", help="Path to Python binary for notebook execution (must have ipykernel installed)"),
+    ] = None,
 ) -> None:
     """Execute notebooks and fill cell outputs.
 
@@ -340,6 +376,7 @@ def fill(
         silent=silent,
         allow_export=allow_export,
         config_path=config_path,
+        python=python,
     )
     if exit_code != 0:
         raise typer.Exit(exit_code)
@@ -384,6 +421,10 @@ def test(
         bool,
         typer.Option("--allow-export", help="Allow nbl_export() during test (disabled by default)"),
     ] = False,
+    python: Annotated[
+        str | None,
+        typer.Option("--python", help="Path to Python binary for notebook execution (must have ipykernel installed)"),
+    ] = None,
 ) -> None:
     """Test that notebooks execute without errors (dry run).
 
@@ -413,6 +454,7 @@ def test(
         silent=silent,
         allow_export=allow_export,
         config_path=config_path,
+        python=python,
     )
     if exit_code != 0:
         raise typer.Exit(exit_code)

--- a/nblite/cli/commands/fill.py
+++ b/nblite/cli/commands/fill.py
@@ -86,7 +86,7 @@ def _run_fill(
     if notebooks:
         # Use specified notebooks
         for nb_path in notebooks:
-            resolved = project.root_path / nb_path if not nb_path.is_absolute() else nb_path
+            resolved = nb_path.resolve()
             if resolved.exists():
                 nbs_to_fill.append(resolved)
             else:

--- a/nblite/cli/commands/prepare.py
+++ b/nblite/cli/commands/prepare.py
@@ -42,6 +42,10 @@ def prepare(
         bool,
         typer.Option("--fill-unchanged", "-f", help="Fill notebooks even if unchanged"),
     ] = False,
+    python: Annotated[
+        str | None,
+        typer.Option("--python", help="Path to Python binary for notebook execution (must have ipykernel installed)"),
+    ] = None,
 ) -> None:
     """Run export, clean, fill, and readme in sequence.
 
@@ -98,6 +102,7 @@ def prepare(
             dry_run=False,
             silent=False,
             config_path=config_path,
+            python=python,
         )
         if exit_code != 0:
             raise typer.Exit(exit_code)

--- a/nblite/config/schema.py
+++ b/nblite/config/schema.py
@@ -304,6 +304,10 @@ class FillConfig(BaseModel):
         default=True,
         description="Exclude .* notebooks",
     )
+    python: str | None = Field(
+        default=None,
+        description="Path to Python binary for notebook execution (must have ipykernel installed)",
+    )
 
 
 class DocsConfig(BaseModel):

--- a/nblite/fill/__init__.py
+++ b/nblite/fill/__init__.py
@@ -16,6 +16,11 @@ from nblite.fill.hash import (
     get_notebook_hash_from_path,
     has_notebook_changed,
 )
+from nblite.fill.kernel import (
+    CUSTOM_KERNEL_NAME,
+    custom_kernel_environment,
+    validate_python_binary,
+)
 
 __all__ = [
     "fill_notebook",
@@ -26,4 +31,7 @@ __all__ = [
     "get_notebook_hash_from_path",
     "has_notebook_changed",
     "HASH_METADATA_KEY",
+    "validate_python_binary",
+    "custom_kernel_environment",
+    "CUSTOM_KERNEL_NAME",
 ]

--- a/nblite/fill/kernel.py
+++ b/nblite/fill/kernel.py
@@ -1,0 +1,140 @@
+"""
+Kernel spec utilities for custom Python binary execution.
+
+Creates temporary Jupyter kernel specs pointing to a user-specified Python
+binary, enabling notebook execution with specific Python environments.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+import tempfile
+from contextlib import contextmanager
+from pathlib import Path
+
+__all__ = [
+    "validate_python_binary",
+    "create_custom_kernel_spec",
+    "custom_kernel_environment",
+    "CUSTOM_KERNEL_NAME",
+]
+
+CUSTOM_KERNEL_NAME = "_nblite_custom"
+
+
+def validate_python_binary(python: str | Path) -> Path:
+    """
+    Validate that a Python binary exists, is executable, and has ipykernel installed.
+
+    Args:
+        python: Path to the Python binary.
+
+    Returns:
+        Absolute Path to the Python binary (without resolving symlinks,
+        to preserve virtual environment paths).
+
+    Raises:
+        FileNotFoundError: If the binary does not exist.
+        PermissionError: If the binary is not executable.
+        RuntimeError: If ipykernel is not installed in the target Python.
+    """
+    python_path = Path(python).absolute()
+
+    if not python_path.exists():
+        raise FileNotFoundError(f"Python binary not found: {python}")
+
+    if not os.access(python_path, os.X_OK):
+        raise PermissionError(f"Python binary is not executable: {python}")
+
+    # Check that ipykernel is installed
+    try:
+        result = subprocess.run(
+            [str(python_path), "-c", "import ipykernel"],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"ipykernel is not installed in {python}. "
+                f"Install it with: {python} -m pip install ipykernel"
+            )
+    except subprocess.TimeoutExpired:
+        raise RuntimeError(f"Timeout checking ipykernel in {python}")
+
+    return python_path
+
+
+def create_custom_kernel_spec(python: str | Path, base_dir: str | Path) -> str:
+    """
+    Create a custom Jupyter kernel spec directory pointing to the given Python.
+
+    Creates the directory structure:
+        base_dir/kernels/_nblite_custom/kernel.json
+
+    Args:
+        python: Path to the Python binary.
+        base_dir: Base directory for the kernel spec (will create kernels/ subdirectory).
+
+    Returns:
+        The kernel name (CUSTOM_KERNEL_NAME).
+    """
+    python_path = Path(python).absolute()
+    base_dir = Path(base_dir)
+
+    kernel_dir = base_dir / "kernels" / CUSTOM_KERNEL_NAME
+    kernel_dir.mkdir(parents=True, exist_ok=True)
+
+    kernel_spec = {
+        "argv": [str(python_path), "-m", "ipykernel_launcher", "-f", "{connection_file}"],
+        "display_name": "nblite custom Python",
+        "language": "python",
+    }
+
+    kernel_json_path = kernel_dir / "kernel.json"
+    kernel_json_path.write_text(json.dumps(kernel_spec, indent=2))
+
+    return CUSTOM_KERNEL_NAME
+
+
+@contextmanager
+def custom_kernel_environment(python: str | Path):
+    """
+    Context manager that sets up a temporary kernel spec for a custom Python binary.
+
+    Creates a temporary directory with a Jupyter kernel spec pointing to the
+    given Python binary, and prepends it to JUPYTER_PATH so jupyter_client
+    finds it. Cleans up on exit.
+
+    Args:
+        python: Path to the Python binary.
+
+    Yields:
+        The kernel name to use with ExecutePreprocessor.
+    """
+    python_path = validate_python_binary(python)
+
+    tmp_dir = tempfile.mkdtemp(prefix="nblite_kernel_")
+    try:
+        kernel_name = create_custom_kernel_spec(python_path, tmp_dir)
+
+        # Prepend to JUPYTER_PATH
+        old_jupyter_path = os.environ.get("JUPYTER_PATH")
+        if old_jupyter_path:
+            os.environ["JUPYTER_PATH"] = f"{tmp_dir}{os.pathsep}{old_jupyter_path}"
+        else:
+            os.environ["JUPYTER_PATH"] = tmp_dir
+
+        yield kernel_name
+    finally:
+        # Restore JUPYTER_PATH
+        if old_jupyter_path is None:
+            os.environ.pop("JUPYTER_PATH", None)
+        else:
+            os.environ["JUPYTER_PATH"] = old_jupyter_path
+
+        # Clean up temp directory
+        shutil.rmtree(tmp_dir, ignore_errors=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dev = [
     "pytest-cov>=4.0.0",
     "ruff>=0.1.0",
     "mypy>=1.0.0",
+    "ipykernel>=6.31.0",
 ]
 
 

--- a/tests/test_fill_kernel.py
+++ b/tests/test_fill_kernel.py
@@ -1,0 +1,181 @@
+"""
+Tests for the kernel spec utility module (nblite.fill.kernel).
+"""
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from nblite.fill.kernel import (
+    CUSTOM_KERNEL_NAME,
+    create_custom_kernel_spec,
+    custom_kernel_environment,
+    validate_python_binary,
+)
+
+
+def _has_ipykernel() -> bool:
+    """Check if ipykernel is importable in the current Python."""
+    result = subprocess.run(
+        [sys.executable, "-c", "import ipykernel"],
+        capture_output=True,
+    )
+    return result.returncode == 0
+
+
+requires_ipykernel = pytest.mark.skipif(
+    not _has_ipykernel(),
+    reason="ipykernel not installed in current environment",
+)
+
+
+class TestValidatePythonBinary:
+    """Tests for validate_python_binary."""
+
+    @requires_ipykernel
+    def test_validates_current_executable(self) -> None:
+        """Test that the current Python executable passes validation."""
+        result = validate_python_binary(sys.executable)
+        assert result == Path(sys.executable).absolute()
+
+    def test_rejects_nonexistent_path(self) -> None:
+        """Test that a nonexistent path raises FileNotFoundError."""
+        with pytest.raises(FileNotFoundError, match="Python binary not found"):
+            validate_python_binary("/nonexistent/path/python")
+
+    def test_rejects_non_executable(self, tmp_path: Path) -> None:
+        """Test that a non-executable file raises PermissionError."""
+        fake_python = tmp_path / "fake_python"
+        fake_python.write_text("not a real python")
+        fake_python.chmod(0o444)  # readable but not executable
+
+        with pytest.raises(PermissionError, match="not executable"):
+            validate_python_binary(fake_python)
+
+    def test_rejects_missing_ipykernel(self, tmp_path: Path) -> None:
+        """Test that a Python without ipykernel raises RuntimeError."""
+        # Create a script that fails on import ipykernel
+        fake_python = tmp_path / "fake_python"
+        fake_python.write_text('#!/bin/sh\necho "ModuleNotFoundError" >&2\nexit 1\n')
+        fake_python.chmod(0o755)
+
+        with pytest.raises(RuntimeError, match="ipykernel is not installed"):
+            validate_python_binary(fake_python)
+
+    @requires_ipykernel
+    def test_returns_absolute_path(self) -> None:
+        """Test that the returned path is absolute."""
+        result = validate_python_binary(sys.executable)
+        assert result.is_absolute()
+
+
+class TestCreateCustomKernelSpec:
+    """Tests for create_custom_kernel_spec."""
+
+    def test_creates_kernel_json(self, tmp_path: Path) -> None:
+        """Test that kernel.json is created with correct structure."""
+        kernel_name = create_custom_kernel_spec(sys.executable, tmp_path)
+
+        assert kernel_name == CUSTOM_KERNEL_NAME
+
+        kernel_json_path = tmp_path / "kernels" / CUSTOM_KERNEL_NAME / "kernel.json"
+        assert kernel_json_path.exists()
+
+        spec = json.loads(kernel_json_path.read_text())
+        assert spec["argv"][0] == str(Path(sys.executable).absolute())
+        assert spec["argv"][1:] == ["-m", "ipykernel_launcher", "-f", "{connection_file}"]
+        assert spec["language"] == "python"
+        assert "display_name" in spec
+
+    def test_creates_directory_structure(self, tmp_path: Path) -> None:
+        """Test that the directory structure is correctly created."""
+        create_custom_kernel_spec(sys.executable, tmp_path)
+
+        assert (tmp_path / "kernels").is_dir()
+        assert (tmp_path / "kernels" / CUSTOM_KERNEL_NAME).is_dir()
+
+    def test_overwrites_existing_spec(self, tmp_path: Path) -> None:
+        """Test that calling twice doesn't fail."""
+        create_custom_kernel_spec(sys.executable, tmp_path)
+        create_custom_kernel_spec(sys.executable, tmp_path)
+
+        kernel_json_path = tmp_path / "kernels" / CUSTOM_KERNEL_NAME / "kernel.json"
+        assert kernel_json_path.exists()
+
+
+@requires_ipykernel
+class TestCustomKernelEnvironment:
+    """Tests for custom_kernel_environment context manager."""
+
+    def test_sets_jupyter_path(self) -> None:
+        """Test that JUPYTER_PATH is set inside context."""
+        old_jupyter_path = os.environ.get("JUPYTER_PATH")
+
+        with custom_kernel_environment(sys.executable) as kernel_name:
+            jupyter_path = os.environ.get("JUPYTER_PATH")
+            assert jupyter_path is not None
+            assert kernel_name == CUSTOM_KERNEL_NAME
+
+            # Verify the temp dir in JUPYTER_PATH contains the kernel spec
+            first_path = jupyter_path.split(os.pathsep)[0]
+            kernel_json = Path(first_path) / "kernels" / CUSTOM_KERNEL_NAME / "kernel.json"
+            assert kernel_json.exists()
+
+        # After context, JUPYTER_PATH should be restored
+        assert os.environ.get("JUPYTER_PATH") == old_jupyter_path
+
+    def test_restores_jupyter_path_on_exit(self) -> None:
+        """Test that JUPYTER_PATH is properly restored."""
+        original = os.environ.get("JUPYTER_PATH")
+
+        # Set a known value
+        os.environ["JUPYTER_PATH"] = "/some/path"
+        try:
+            with custom_kernel_environment(sys.executable):
+                # Should be prepended
+                assert os.environ["JUPYTER_PATH"].endswith(f"{os.pathsep}/some/path")
+
+            # Should be restored
+            assert os.environ["JUPYTER_PATH"] == "/some/path"
+        finally:
+            # Restore original
+            if original is None:
+                os.environ.pop("JUPYTER_PATH", None)
+            else:
+                os.environ["JUPYTER_PATH"] = original
+
+    def test_cleans_up_temp_dir(self) -> None:
+        """Test that the temp directory is cleaned up after context."""
+        temp_dir_path = None
+
+        with custom_kernel_environment(sys.executable):
+            jupyter_path = os.environ["JUPYTER_PATH"]
+            temp_dir_path = jupyter_path.split(os.pathsep)[0]
+            assert Path(temp_dir_path).exists()
+
+        # Temp dir should be cleaned up
+        assert not Path(temp_dir_path).exists()
+
+    def test_restores_on_exception(self) -> None:
+        """Test that cleanup happens even on exception."""
+        old_jupyter_path = os.environ.get("JUPYTER_PATH")
+        temp_dir_path = None
+
+        with pytest.raises(ValueError):
+            with custom_kernel_environment(sys.executable):
+                jupyter_path = os.environ["JUPYTER_PATH"]
+                temp_dir_path = jupyter_path.split(os.pathsep)[0]
+                raise ValueError("test error")
+
+        # Should be cleaned up
+        assert os.environ.get("JUPYTER_PATH") == old_jupyter_path
+        assert not Path(temp_dir_path).exists()
+
+    def test_yields_kernel_name(self) -> None:
+        """Test that the context manager yields the correct kernel name."""
+        with custom_kernel_environment(sys.executable) as kernel_name:
+            assert kernel_name == CUSTOM_KERNEL_NAME

--- a/tests/test_fill_python_binary.py
+++ b/tests/test_fill_python_binary.py
@@ -14,9 +14,6 @@ from pathlib import Path
 
 import pytest
 
-# Skip all tests in this module if uv is not available
-pytestmark = pytest.mark.slow
-
 
 def _uv_available() -> bool:
     """Check if uv is available on the system."""

--- a/tests/test_fill_python_binary.py
+++ b/tests/test_fill_python_binary.py
@@ -1,0 +1,315 @@
+"""
+Integration tests for the --python option with actual virtual environments.
+
+These tests create real venvs using uv and verify that notebook execution
+uses the correct Python binary.
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+# Skip all tests in this module if uv is not available
+pytestmark = pytest.mark.slow
+
+
+def _uv_available() -> bool:
+    """Check if uv is available on the system."""
+    return shutil.which("uv") is not None
+
+
+@pytest.fixture
+def venv_with_ipykernel(tmp_path: Path):
+    """
+    Create a virtual environment with ipykernel installed using uv.
+
+    Yields the path to the Python binary in the venv.
+    """
+    if not _uv_available():
+        pytest.skip("uv is not available")
+
+    venv_dir = tmp_path / "test_venv"
+
+    # Create venv
+    result = subprocess.run(
+        ["uv", "venv", str(venv_dir), "--python", sys.executable],
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"Failed to create venv: {result.stderr}")
+
+    python_path = venv_dir / "bin" / "python"
+    if not python_path.exists():
+        # Windows
+        python_path = venv_dir / "Scripts" / "python.exe"
+
+    if not python_path.exists():
+        pytest.skip("Could not find python in venv")
+
+    # Install ipykernel
+    result = subprocess.run(
+        ["uv", "pip", "install", "ipykernel", "--python", str(python_path)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        pytest.skip(f"Failed to install ipykernel: {result.stderr}")
+
+    # Verify ipykernel is actually importable
+    verify = subprocess.run(
+        [str(python_path), "-c", "import ipykernel"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if verify.returncode != 0:
+        pytest.skip(f"ipykernel not importable after install: {verify.stderr}")
+
+    yield python_path
+
+
+def create_notebook_that_prints_executable(path: Path) -> Path:
+    """Create a notebook that prints sys.executable to stdout."""
+    nb_content = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "id": "cell-0",
+                "source": "import sys\nprint(sys.executable)",
+                "metadata": {},
+                "outputs": [],
+                "execution_count": None,
+            }
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb_content))
+    return path
+
+
+def create_simple_notebook(path: Path) -> Path:
+    """Create a simple notebook for testing."""
+    nb_content = {
+        "cells": [
+            {
+                "cell_type": "code",
+                "id": "cell-0",
+                "source": "x = 1 + 1\nprint(x)",
+                "metadata": {},
+                "outputs": [],
+                "execution_count": None,
+            }
+        ],
+        "metadata": {},
+        "nbformat": 4,
+        "nbformat_minor": 5,
+    }
+    path.write_text(json.dumps(nb_content))
+    return path
+
+
+class TestFillNotebookWithVenvPython:
+    """Test fill_notebook with a venv Python binary."""
+
+    def test_fill_notebook_with_venv_python(self, tmp_path: Path, venv_with_ipykernel: Path) -> None:
+        """Test that fill_notebook uses the specified Python binary."""
+        from nblite.fill import fill_notebook, FillStatus
+
+        nb_path = create_notebook_that_prints_executable(tmp_path / "test.ipynb")
+
+        result = fill_notebook(nb_path, python=venv_with_ipykernel)
+
+        assert result.status == FillStatus.SUCCESS
+
+        # Check that the output contains the venv python path
+        nb_data = json.loads(nb_path.read_text())
+        outputs = nb_data["cells"][0]["outputs"]
+        assert len(outputs) > 0
+        # Stream output text can be a string or list of strings
+        raw_text = outputs[0].get("text", "")
+        output_text = "".join(raw_text) if isinstance(raw_text, list) else raw_text
+        # The venv python should be within the venv dir
+        venv_dir = str(venv_with_ipykernel.parent.parent)
+        assert venv_dir in output_text or str(venv_with_ipykernel) in output_text
+
+    def test_fill_notebooks_batch_with_venv(self, tmp_path: Path, venv_with_ipykernel: Path) -> None:
+        """Test batch fill_notebooks with a venv Python."""
+        from nblite.fill import fill_notebooks, FillStatus
+
+        paths = [
+            create_simple_notebook(tmp_path / f"nb{i}.ipynb")
+            for i in range(2)
+        ]
+
+        results = fill_notebooks(
+            paths,
+            skip_unchanged=False,
+            python=venv_with_ipykernel,
+        )
+
+        assert len(results) == 2
+        assert all(r.status == FillStatus.SUCCESS for r in results)
+
+    def test_fill_notebooks_parallel_with_venv(self, tmp_path: Path, venv_with_ipykernel: Path) -> None:
+        """Test parallel fill_notebooks with a venv Python."""
+        from nblite.fill import fill_notebooks, FillStatus
+
+        paths = [
+            create_simple_notebook(tmp_path / f"nb{i}.ipynb")
+            for i in range(3)
+        ]
+
+        results = fill_notebooks(
+            paths,
+            skip_unchanged=False,
+            n_workers=2,
+            python=venv_with_ipykernel,
+        )
+
+        assert len(results) == 3
+        assert all(r.status == FillStatus.SUCCESS for r in results)
+
+
+class TestFillCLIWithPython:
+    """Test CLI commands with --python option."""
+
+    def test_fill_cli_with_python_option(self, tmp_path: Path, venv_with_ipykernel: Path) -> None:
+        """Test nbl fill --python with a venv."""
+        from typer.testing import CliRunner
+
+        from nblite.cli.app import app
+
+        # Set up project
+        nbs_dir = tmp_path / "nbs"
+        nbs_dir.mkdir()
+        config = """
+[cl.nbs]
+path = "nbs"
+format = "ipynb"
+"""
+        (tmp_path / "nblite.toml").write_text(config)
+
+        nb_path = create_simple_notebook(nbs_dir / "test.ipynb")
+
+        runner = CliRunner()
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = runner.invoke(
+                app, ["fill", "--python", str(venv_with_ipykernel), str(nb_path)]
+            )
+        finally:
+            os.chdir(original_cwd)
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+
+    def test_test_cli_with_python_option(self, tmp_path: Path, venv_with_ipykernel: Path) -> None:
+        """Test nbl test --python with a venv."""
+        from typer.testing import CliRunner
+
+        from nblite.cli.app import app
+
+        # Set up project
+        nbs_dir = tmp_path / "nbs"
+        nbs_dir.mkdir()
+        config = """
+[cl.nbs]
+path = "nbs"
+format = "ipynb"
+"""
+        (tmp_path / "nblite.toml").write_text(config)
+
+        nb_path = create_simple_notebook(nbs_dir / "test.ipynb")
+
+        runner = CliRunner()
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = runner.invoke(
+                app, ["test", "--python", str(venv_with_ipykernel), str(nb_path)]
+            )
+        finally:
+            os.chdir(original_cwd)
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+
+    def test_fill_config_python_in_toml(self, tmp_path: Path, venv_with_ipykernel: Path) -> None:
+        """Test python specification via nblite.toml config."""
+        from typer.testing import CliRunner
+
+        from nblite.cli.app import app
+
+        # Set up project with python in config
+        nbs_dir = tmp_path / "nbs"
+        nbs_dir.mkdir()
+        config = f"""
+[cl.nbs]
+path = "nbs"
+format = "ipynb"
+
+[fill]
+python = "{venv_with_ipykernel}"
+"""
+        (tmp_path / "nblite.toml").write_text(config)
+
+        nb_path = create_simple_notebook(nbs_dir / "test.ipynb")
+
+        runner = CliRunner()
+        original_cwd = os.getcwd()
+        try:
+            os.chdir(tmp_path)
+            result = runner.invoke(app, ["fill", str(nb_path)])
+        finally:
+            os.chdir(original_cwd)
+
+        assert result.exit_code == 0, f"CLI failed: {result.output}"
+
+
+class TestFillCLIPythonHelp:
+    """Test that --python appears in CLI help."""
+
+    def test_fill_python_option_in_help(self) -> None:
+        """Test --python option appears in fill --help."""
+        from typer.testing import CliRunner
+
+        from nblite.cli.app import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["fill", "--help"])
+
+        assert result.exit_code == 0
+        assert "--python" in result.output
+
+    def test_test_python_option_in_help(self) -> None:
+        """Test --python option appears in test --help."""
+        from typer.testing import CliRunner
+
+        from nblite.cli.app import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["test", "--help"])
+
+        assert result.exit_code == 0
+        assert "--python" in result.output
+
+    def test_prepare_python_option_in_help(self) -> None:
+        """Test --python option appears in prepare --help."""
+        from typer.testing import CliRunner
+
+        from nblite.cli.app import app
+
+        runner = CliRunner()
+        result = runner.invoke(app, ["prepare", "--help"])
+
+        assert result.exit_code == 0
+        assert "--python" in result.output

--- a/uv.lock
+++ b/uv.lock
@@ -546,7 +546,7 @@ name = "exceptiongroup"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
@@ -1356,7 +1356,7 @@ wheels = [
 
 [[package]]
 name = "nblite"
-version = "1.1.9"
+version = "1.1.14"
 source = { editable = "." }
 dependencies = [
     { name = "jinja2" },
@@ -1381,6 +1381,7 @@ docs = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "ipykernel" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1408,6 +1409,7 @@ provides-extras = ["docs"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "ipykernel", specifier = ">=6.31.0" },
     { name = "mypy", specifier = ">=1.0.0" },
     { name = "pytest", specifier = ">=9.0.2" },
     { name = "pytest-cov", specifier = ">=4.0.0" },


### PR DESCRIPTION
## Summary

- Add `--python` option to `nbl fill`, `nbl test`, and `nbl prepare` for specifying a custom Python binary (must have ipykernel installed)
- Support configuring the Python binary in `nblite.toml` under `[fill] python = "..."`
- Allow `nbl fill` and `nbl test` to run without an nblite project when explicit notebook paths are provided
- Fix notebook path resolution to use cwd instead of project root

## Test plan

- [x] `nbl fill notebook.ipynb` works without nblite.toml when explicit paths given
- [x] `nbl test notebook.ipynb` works without nblite.toml when explicit paths given
- [x] `nbl fill` (no args) still errors with "No nblite.toml found"
- [x] All 64 existing fill tests pass (`test_fill.py`, `test_fill_kernel.py`, `test_fill_python_binary.py`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)